### PR TITLE
New first line on our site

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,8 @@ export default function Home() {
       <HeroSection />
       <Section className='overflow-y-hidden'>
         <BarDecoration />
-        <Subheading>About Paragon</Subheading>
+
+        <Subheading>We are a think tank run by student volunteers.</Subheading>
 
         
         <div>


### PR DESCRIPTION
<Subheading>About Paragon</Subheading>

was replaced with

<Subheading>We are a think tank run by student volunteers.</Subheading>

I believe this makes our identity much more clear than the current text we have on our page, though it is more of a bandaid